### PR TITLE
Add flexible quantization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
 # Danger
+
+This project aims to create a custom operating system for Google Pixel devices that enables running a large language model directly on the phone. The goal is to provide on-device AI capabilities without relying on cloud services.
+
+The repository contains early scripts and documentation for building the OS image, integrating the LLM, and flashing the custom OS onto the device. Development is still in the early stages, so expect many features to evolve over time.
+
+## Code Overview
+
+This repository will be organized into the following parts:
+
+- **bootloader/** – scripts and configuration for unlocking and modifying the Pixel's bootloader.
+- **aosp_build/** – instructions and patches for compiling the Android Open Source Project with custom changes.
+- **llm_integration/** – code for deploying a lightweight language model onto the device, including model files and inference libraries.
+- **flashing_tools/** – utilities for packaging the OS image and flashing it to the phone.
+- **docs/** – additional documentation on development setup and usage.
+
+The repository now contains initial scripts in each directory to help kickstart development. These scripts handle bootloader unlocking, fetching and building AOSP, downloading an example LLM model, and flashing the resulting image.
+
+## Getting Started
+
+To eventually build the custom OS you will need:
+
+- An unlocked Pixel bootloader with USB debugging enabled.
+- A Linux machine configured with Android build dependencies.
+- Familiarity with ADB and Fastboot command line tools.
+
+Once development begins, the general workflow will involve:
+
+1. Cloning AOSP sources and applying patches in `aosp_build/`.
+2. Compiling the system image and kernel.
+3. Integrating an offline LLM in `llm_integration/` (e.g., via TensorFlow Lite).
+4. Packaging the result and flashing it with tools from `flashing_tools/`.
+5. Use `setup_llama_cpp.sh` and `run_llama_cpp.sh` in `llm_integration/` to build and test `llama.cpp` models.
+
+## Learning More
+
+New contributors are encouraged to read Google's [building for devices](https://source.android.com/setup/build) guide and explore the source within each directory as it is created. Useful topics to research next include:
+
+- Android boot process and partition layout.
+- Fastboot commands for flashing images.
+- Optimizing small language models for mobile hardware.
+
+As the repository grows, the `/docs` directory will contain detailed walkthroughs and examples.
+
+
+Additional device-specific tips can be found in docs/pixel5_llm.md.
+See docs/quantize_mistral.md for Mistral quantization instructions, including an AWQ example script.

--- a/aosp_build/build.sh
+++ b/aosp_build/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Builds the custom AOSP image.
+
+set -e
+
+if [ -z "$AOSP_DIR" ]; then
+  AOSP_DIR=$PWD/aosp
+fi
+
+cd "$AOSP_DIR"
+
+source build/envsetup.sh
+lunch aosp_sailfish-userdebug
+
+# Example: disable verity for userdebug build
+export TARGET_AVB_ENABLE=false
+
+make -j$(nproc) otapackage
+
+OUTPUT_DIR="$(dirname "$0")/out"
+mkdir -p "$OUTPUT_DIR"
+cp out/target/product/*/obj/PACKAGING/target_files_intermediates/*.zip "$OUTPUT_DIR"/ || true

--- a/aosp_build/setup.sh
+++ b/aosp_build/setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Fetches AOSP sources and applies project-specific patches.
+
+set -e
+
+if [ -z "$AOSP_DIR" ]; then
+  AOSP_DIR=$PWD/aosp
+fi
+
+mkdir -p "$AOSP_DIR"
+cd "$AOSP_DIR"
+
+# Initialize repo
+repo init -u https://android.googlesource.com/platform/manifest -b android-14.0.0_r1
+
+# Sync sources (this may take a long time)
+repo sync -c -j$(nproc)
+
+# Apply patches from repository
+PATCH_DIR="$(cd "$(dirname "$0")" && pwd)/patches"
+if [ -d "$PATCH_DIR" ]; then
+  for patch in "$PATCH_DIR"/*.patch; do
+    [ -f "$patch" ] || continue
+    echo "Applying $patch"
+    git -C "$AOSP_DIR" apply "$patch"
+  done
+fi

--- a/bootloader/unlock_bootloader.sh
+++ b/bootloader/unlock_bootloader.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Unlocks the Pixel bootloader. WARNING: this will wipe the device.
+
+set -e
+
+if ! command -v fastboot >/dev/null; then
+  echo "fastboot not found. Please install Android platform-tools." >&2
+  exit 1
+fi
+
+echo "\nRebooting to bootloader..."
+adb reboot bootloader
+
+sleep 5
+
+echo "\nUnlocking bootloader..."
+fastboot flashing unlock
+
+cat <<MSG
+\nBootloader unlocked. You must confirm the unlock on the device screen.\n\nAfter unlocking, the device will reboot and perform a factory reset.\nMSG

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Project Documentation
+
+This directory will contain detailed guides for building and flashing the custom OS. As development progresses, look here for step-by-step instructions and troubleshooting tips.
+
+See pixel5_llm.md for optimizing a Verizon Pixel 5 for local LLM inference.
+
+See quantize_mistral.md for instructions on preparing a Mistral model for edge devices, including an optional AWQ quantization workflow.

--- a/docs/pixel5_llm.md
+++ b/docs/pixel5_llm.md
@@ -1,0 +1,31 @@
+# Optimizing a Verizon-Locked Pixel 5 for On-Device LLMs
+
+This guide summarizes best practices for running language models on a Pixel 5 that cannot be rooted or have its bootloader unlocked.
+
+## Bootloader and Root Access
+- Verizon Pixel 5 units have the OEM unlocking toggle disabled by design.
+- As of 2025 there are no public exploits to unlock or root these models.
+- Development therefore focuses on user-space tools only.
+
+## Recommended Runtime Environments
+- **Termux** provides a lightweight Linux shell for compiling and running tools like `llama.cpp`. This typically offers the best CPU performance.
+- **MLC Chat** is an Android app that bundles optimized kernels and a simple UI. Performance is similar to Termux on CPU-only devices.
+- Python-based environments such as Pydroid 3 work but have higher overhead.
+
+## Suggested Models
+- Small models (\<=7B parameters) quantized to 4-bit are most practical on 8 GB of RAM.
+- `Phi-2` (2.7B) and `TinyLlama` (1.1B) offer a good balance of quality and speed.
+
+## Example Termux Workflow
+```bash
+pkg install git clang make cmake
+git clone https://github.com/ggerganov/llama.cpp.git
+cd llama.cpp && make -j4
+./main -m ~/phi2-2.7B.Q4_K_M.gguf -t 4 -c 2048
+```
+This downloads and builds `llama.cpp` then runs the model with reasonable defaults.
+You can also run `../llm_integration/setup_llama_cpp.sh` followed by `../llm_integration/run_llama_cpp.sh <model>` if you have cloned the repository on the device.
+
+For the latest quantization techniques, see `docs/quantize_mistral.md` which covers converting Mistral with AWQ for even smaller models.
+
+For more details see the README in the repository root.

--- a/docs/quantize_mistral.md
+++ b/docs/quantize_mistral.md
@@ -1,0 +1,72 @@
+# Quantizing Mistral for Edge Devices
+
+This guide explains how to convert and quantize the Mistral 7B model so it can run efficiently on constrained hardware like mobile phones or single‑board computers.
+
+## Prerequisites
+
+- **Python 3.10+** with `pip`
+- [`transformers`](https://pypi.org/project/transformers/) and [`sentencepiece`](https://pypi.org/project/sentencepiece/) Python packages
+- [`git-lfs`](https://git-lfs.github.com/) for downloading model weights from Hugging Face
+- `cmake` and a C++ compiler for building [llama.cpp](https://github.com/ggerganov/llama.cpp)
+- Sufficient disk space to store the original model (~13 GB)
+
+## Steps
+
+1. **Download the base model**
+   ```bash
+   git lfs install
+   git clone https://huggingface.co/mistralai/Mistral-7B-v0.1
+   ```
+   This creates a directory `Mistral-7B-v0.1` containing the FP16 weights.
+
+2. **Build `llama.cpp`**
+   ```bash
+   ./llm_integration/setup_llama_cpp.sh
+   ```
+   This clones `llama.cpp` under `llm_integration/llama.cpp` and compiles the tools.
+
+3. **Convert to GGUF format**
+   ```bash
+   python3 llm_integration/llama.cpp/convert-hf-to-gguf.py \
+       Mistral-7B-v0.1 --outfile mistral-f16.gguf --outtype f16
+   ```
+   The result `mistral-f16.gguf` is easier to quantize and loads faster.
+
+4. **Quantize the model (GGUF)**
+   ```bash
+   llm_integration/llama.cpp/quantize \
+       mistral-f16.gguf mistral-q4_K_M.gguf q4_K_M
+   ```
+   The `q4_K_M` quantization yields a good trade‑off between quality and size.
+   You can use other types such as `q2_K` or `q3_K` for smaller models:
+   ```bash
+   llm_integration/quantize_mistral.sh Mistral-7B-v0.1 ./out q2_K
+   ```
+   The output file will include the quantization type (e.g. `mistral-q2_K.gguf`).
+
+5. *(Optional)* **Quantize with AWQ**
+   AWQ (Activation-aware Weight Quantization) can produce even smaller models
+   while retaining quality. Install the `autoawq` package and run:
+   ```bash
+   python3 llm_integration/quantize_mistral_awq.py Mistral-7B-v0.1 awq_out --bits 2
+   ```
+   Replace `2` with the desired bit-width (2–8). The resulting directory
+   `awq_out/` contains AWQ weights that compatible runtimes can load.
+
+6. **Run the quantized model**
+   ```bash
+   llm_integration/run_llama_cpp.sh mistral-q4.gguf -t 6 -c 2048
+   ```
+   Adjust the thread count (`-t`) for your hardware.
+
+## Tips
+
+- You can experiment with other quantization types like `q5_K_M` or `q8_0` for
+  higher accuracy at the cost of size and speed.
+- Extremely low bit widths (e.g. "1.7-bit") are not currently supported in
+  mainstream tooling. The smallest widely available option is 2-bit
+  quantization using `q2_K` or the `--bits 2` AWQ setting.
+- After quantization the original FP16 GGUF file can be deleted to save space.
+- Smaller models such as `Mixtral-8x7B-Instruct` can be quantized in the same
+  way; just change the source repository.
+

--- a/flashing_tools/flash.sh
+++ b/flashing_tools/flash.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Flashes the compiled OS image to the device.
+
+set -e
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <target_files.zip>" >&2
+  exit 1
+fi
+
+IMAGE_ZIP=$1
+
+if ! command -v fastboot >/dev/null; then
+  echo "fastboot not found" >&2
+  exit 1
+fi
+
+unzip -o "$IMAGE_ZIP" -d /tmp/os_image
+cd /tmp/os_image
+
+./flash-all.sh

--- a/llm_integration/README.md
+++ b/llm_integration/README.md
@@ -1,0 +1,10 @@
+# LLM Integration
+
+This directory contains scripts and configuration for running a lightweight language model on the Pixel.
+
+The general approach is to use TensorFlow Lite (or an alternative inference engine) to run the model offline. The actual model weights are not included in the repository.
+
+Scripts will download the model, convert it to a mobile-friendly format, and place the files under `llm_integration/model/`.
+
+For experimentation, run `setup_llama_cpp.sh` to build [llama.cpp](https://github.com/ggerganov/llama.cpp). Use `run_llama_cpp.sh <model>` to execute a downloaded GGUF model.
+You can also convert and quantize a Mistral model using `quantize_mistral.sh <hf-model-dir> [out-dir]`. See `../docs/quantize_mistral.md` for details.

--- a/llm_integration/quantize_mistral.sh
+++ b/llm_integration/quantize_mistral.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Converts and quantizes a Mistral model using llama.cpp.
+# Usage: ./quantize_mistral.sh <path-to-hf-model> [output-dir] [quant-type]
+set -e
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <hf_model_dir> [output_dir] [quant_type]" >&2
+  exit 1
+fi
+
+MODEL_DIR="$1"
+OUT_DIR="${2:-$(pwd)}"
+QUANT_TYPE="${3:-q4_K_M}"
+LLAMA_DIR="$(dirname "$0")/llama.cpp"
+
+if [ ! -d "$LLAMA_DIR" ]; then
+  echo "llama.cpp not found. Run setup_llama_cpp.sh first." >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+F16_GGUF="$OUT_DIR/mistral-f16.gguf"
+Q4_GGUF="$OUT_DIR/mistral-${QUANT_TYPE}.gguf"
+
+python3 "$LLAMA_DIR/convert-hf-to-gguf.py" "$MODEL_DIR" --outfile "$F16_GGUF" --outtype f16
+"$LLAMA_DIR/quantize" "$F16_GGUF" "$Q4_GGUF" "$QUANT_TYPE"
+
+echo "Quantized model written to $Q4_GGUF"

--- a/llm_integration/quantize_mistral_awq.py
+++ b/llm_integration/quantize_mistral_awq.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Quantize a Mistral model using AutoAWQ.
+
+This script converts a Hugging Face Mistral model to AWQ (activation-aware weight
+quantization) format for efficient inference with libraries such as
+llama.cpp or awq loaders.
+
+Usage:
+    python3 quantize_mistral_awq.py <path-to-hf-model> [output-dir] [--bits N]
+
+The script requires the `autoawq` Python package.
+"""
+
+import argparse
+import os
+import subprocess
+from pathlib import Path
+
+try:
+    from awq import AutoAWQForCausalLM
+    from transformers import AutoTokenizer
+except ImportError as e:
+    raise SystemExit(
+        "autoawq not installed. Install with 'pip install autoawq transformers'."
+    ) from e
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Quantize Mistral with AWQ")
+    parser.add_argument("hf_model", help="Path to downloaded Hugging Face model")
+    parser.add_argument(
+        "output", nargs="?", default="./awq_out", help="Directory for quantized model"
+    )
+    parser.add_argument(
+        "--bits",
+        type=int,
+        default=4,
+        help="Number of bits for weight quantization (2-8)",
+    )
+    args = parser.parse_args()
+
+    model_path = Path(args.hf_model).resolve()
+    out_dir = Path(args.output).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Loading model from {model_path}...", flush=True)
+    model = AutoAWQForCausalLM.from_pretrained(model_path, trust_remote_code=True)
+    tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=False)
+
+    if not 2 <= args.bits <= 8:
+        raise SystemExit("bits must be between 2 and 8")
+
+    print(f"Quantizing with AWQ to {args.bits}-bit weights...", flush=True)
+    model.quantize(
+        tokenizer,
+        quant_config={"zero_point": True, "bits": args.bits, "group_size": 128},
+    )
+
+    print(f"Saving quantized model to {out_dir}...", flush=True)
+    model.save_quantized(out_dir)
+    tokenizer.save_pretrained(out_dir)
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/llm_integration/run_llama_cpp.sh
+++ b/llm_integration/run_llama_cpp.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Runs a model using llama.cpp after setup.
+
+set -e
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <model-file> [extra args...]" >&2
+  exit 1
+fi
+
+MODEL=$1
+shift
+
+LLAMA_DIR="$(dirname "$0")/llama.cpp"
+if [ ! -f "$LLAMA_DIR/main" ] && [ ! -f "$LLAMA_DIR/build/bin/main" ]; then
+  echo "llama.cpp not built. Run setup_llama_cpp.sh first." >&2
+  exit 1
+fi
+
+# Prefer build/bin/main if exists
+LLAMA_BIN="$LLAMA_DIR/build/bin/main"
+if [ ! -f "$LLAMA_BIN" ]; then
+  LLAMA_BIN="$LLAMA_DIR/main"
+fi
+
+"$LLAMA_BIN" -m "$MODEL" "$@"

--- a/llm_integration/setup_llama_cpp.sh
+++ b/llm_integration/setup_llama_cpp.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Clones and builds llama.cpp for running models locally.
+
+set -e
+
+LLAMA_DIR="$(dirname "$0")/llama.cpp"
+if [ ! -d "$LLAMA_DIR" ]; then
+  git clone https://github.com/ggerganov/llama.cpp.git "$LLAMA_DIR"
+fi
+
+cd "$LLAMA_DIR"
+make -j$(nproc)
+
+echo "llama.cpp built in $LLAMA_DIR"

--- a/llm_integration/setup_model.sh
+++ b/llm_integration/setup_model.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Downloads and prepares the LLM for on-device use.
+
+set -e
+
+MODEL_DIR="$(dirname "$0")/model"
+mkdir -p "$MODEL_DIR"
+
+MODEL_URL="https://example.com/path/to/llm.tflite"
+MODEL_FILE="$MODEL_DIR/llm.tflite"
+
+if [ ! -f "$MODEL_FILE" ]; then
+  echo "Downloading model..."
+  curl -L "$MODEL_URL" -o "$MODEL_FILE"
+fi
+
+echo "Model placed in $MODEL_FILE"


### PR DESCRIPTION
## Summary
- allow specifying quantization type in `quantize_mistral.sh`
- add `--bits` flag in `quantize_mistral_awq.py`
- document q2 and q3 usage and note 2‑bit minimum

## Testing
- `bash -n llm_integration/quantize_mistral.sh`
- `python3 llm_integration/quantize_mistral_awq.py --help` *(fails: autoawq not installed)*


------
https://chatgpt.com/codex/tasks/task_e_684e41d568f0832a8ce20e3cf3dfc7ec